### PR TITLE
[unittest] buy fail if account not enough

### DIFF
--- a/TradingSystem/test.cpp
+++ b/TradingSystem/test.cpp
@@ -177,3 +177,15 @@ TEST_F(TradeItem, buyNiceTiming_FAIL) {
 	EXPECT_EQ(expectedStockCount, app.getMyStock(code));
 	EXPECT_EQ(expectedRemainAccount, app.getTotalAccount());
 }
+
+
+TEST_F(TradeItem, CallApiTest_BUYFAIL) {
+
+	int price = 1000;
+	int amount = 1;
+	AutoTradingSystem app{ &mock };
+	app.setTotalAccount(0);
+	EXPECT_CALL(mock, buy(code, price, amount))
+		.Times(1);
+	EXPECT_THROW(app.buy(code, price, amount), std::exception);
+}


### PR DESCRIPTION
예수금이 부족할 경우 exception 발생