### PR TITLE
fix buy feature for exception

### DIFF
--- a/TradingSystem/AutoTradingSystem.cpp
+++ b/TradingSystem/AutoTradingSystem.cpp
@@ -4,6 +4,7 @@
 #include <thread>
 #include <chrono>
 #include <map>
+#include <stdexcept>
 
 class AutoTradingSystem {
 public:
@@ -18,6 +19,11 @@ public:
 		return brocker->isLoggedin();
 	}
 	void buy(const std::string& code, int price, int amount) {
+
+		if (price * amount > deposit)
+		{
+			throw std::exception("You don't have enough money");
+		}
 
 		brocker->buy(code, price, amount);
 		myStock[code] += amount;

--- a/TradingSystem/test.cpp
+++ b/TradingSystem/test.cpp
@@ -42,6 +42,8 @@ TEST_F(TradeItem, CallApiTest_BUY) {
 	int price = 1000;
 	int amount = 1;
 	AutoTradingSystem app{ &mock };
+	app.setTotalAccount(2000);
+
 	EXPECT_CALL(mock, buy( code, price, amount))
 		.Times(1);
 	app.buy(code, price, amount);
@@ -98,6 +100,7 @@ TEST_F(TradeItem, getMyStockCount) {
 	int price = 1000;
 	int amount = 1;
 	AutoTradingSystem app{ &mock };
+	app.setTotalAccount(myTotalAccount);
 
 	app.buy(code, 1000, 3); // buy 3 stock
 	EXPECT_EQ(3, app.getMyStock(code)); // check if 3 stock is in my account
@@ -108,6 +111,8 @@ TEST_F(TradeItem, buyNiceTiming_CallGetPriceThreeTimes) {
 	int price = 1000;
 	int amount = 1;
 	AutoTradingSystem app{ &mock };
+	app.setTotalAccount(totalPrice);
+
 	EXPECT_CALL(mock, getPrice(code))
 		.Times(3)
 		.WillOnce(Return(1))
@@ -185,7 +190,8 @@ TEST_F(TradeItem, CallApiTest_BUYFAIL) {
 	int amount = 1;
 	AutoTradingSystem app{ &mock };
 	app.setTotalAccount(0);
-	
+	EXPECT_CALL(mock, buy(code, price, amount))
+		.Times(0);
 	EXPECT_THROW(app.buy(code, price, amount), std::exception);
 }
 


### PR DESCRIPTION
buy할 때 예수금보다 크면 excepton throw 하도록 함.
buy fail UT에서 exception 발생하면 brokerdriver에서 buy를 호출 안 할 것이므로 UT 내에서 brokerdriver 호출 수 0번을 의도하도록 UT 수정
Buy UT에서 예수금 없이 buy하도록 되어 있어서 Buy UT에서 처음에 예수금 있도록 수정